### PR TITLE
Fixed flex on Safari

### DIFF
--- a/css/media.css
+++ b/css/media.css
@@ -5,10 +5,9 @@
     }
 
     /* Flex */
-    .flex-container .row,
-    .flex-container .row-reverse {
-        flex-direction: column;
-        flex: 1 1 0px;
+    .flex-container .column {
+        flex: 100%;
+        max-width: 100%;
     }
 
     /* Hero image */

--- a/css/media.css
+++ b/css/media.css
@@ -8,6 +8,7 @@
     .flex-container .row,
     .flex-container .row-reverse {
         flex-direction: column;
+        flex: 1 1 0px;
     }
 
     /* Hero image */

--- a/css/utilities.css
+++ b/css/utilities.css
@@ -54,17 +54,20 @@
 .flex-container {
     display: flex;
     flex-direction: column;
+    flex: 1 1 0px;
 }
 .flex-container .row {
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
+    flex: 1 1 0px;
     width: 100%;
 }
 .flex-container .row-reverse {
     display: flex;
     flex-direction: row-reverse;
     flex-wrap: wrap;
+    flex: 1 1 0px;
     width: 100%;
 }
 .flex-container .column {

--- a/css/utilities.css
+++ b/css/utilities.css
@@ -54,20 +54,17 @@
 .flex-container {
     display: flex;
     flex-direction: column;
-    flex: 1 1 0px;
 }
 .flex-container .row {
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
-    flex: 1 1 0px;
     width: 100%;
 }
 .flex-container .row-reverse {
     display: flex;
     flex-direction: row-reverse;
     flex-wrap: wrap;
-    flex: 1 1 0px;
     width: 100%;
 }
 .flex-container .column {


### PR DESCRIPTION
Closes #1 
More responsive flex that works in all major browsers - columns take 100% of width instead of changing flex-direction